### PR TITLE
JUnit 5 dependency, Mockito -> MockK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,10 @@ android {
         }
     }
 
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -60,19 +64,35 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.preference:preference:1.1.1'
-    implementation 'org.mockito:mockito-android:3.4.6'
-    testImplementation 'junit:junit:4.13'
+
+
+    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation 'org.mockito:mockito-core:3.4.6'
+    testImplementation 'com.google.truth:truth:1.0.1'
+    testImplementation "io.mockk:mockk:1.10.0"
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
-    // Versions
     def lifecycle_version = "2.2.0"
     def room_version = "2.2.5"
     def coroutines_version = "1.3.6"
     def retrofit2_version = "2.9.0"
+    def junit4_version = "4.13"
+    def junit5_version = "5.6.2"
 
-    // Architectural Components
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    // (Required) Writing and executing Unit Tests on the JUnit Platform
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
+
+    // (Optional) If you need "Parameterized Tests"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5_version"
+
+    // (Optional) If you also have JUnit 4-based tests
+
+    testImplementation "junit:junit:$junit4_version"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit5_version"
 
     // Room
     implementation "androidx.room:room-runtime:$room_version"

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ buildscript {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$navigation_version"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
         classpath "com.hiya:jacoco-android:0.2"
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.3.1.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Upgrade to JUnit 5 but keep JUnit 4 for compatability.  
Change from using Mockito to MockK to support Kotlin's final classes.  

[Gradle Changes for JUnit 5 blindly followed this SO answer](https://stackoverflow.com/a/53674289/9713161)  
[Motivation for JUnit 5 and MockK](https://www.youtube.com/watch?v=RX_g65J14H0)
