### PR TITLE
Rename packages: utils -> util

### DIFF
--- a/app/src/androidTest/java/com/sthoray/allright/data/db/SearchHistoryDatabaseTest.kt
+++ b/app/src/androidTest/java/com/sthoray/allright/data/db/SearchHistoryDatabaseTest.kt
@@ -9,7 +9,7 @@ import com.google.common.truth.Truth.assertThat
 import com.sthoray.allright.util.TestUtil
 import com.sthoray.allright.data.model.search.SearchRequest
 import com.sthoray.allright.util.blockingObserve
-import com.sthoray.allright.utils.SortOrder
+import com.sthoray.allright.util.SortOrder
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before

--- a/app/src/main/java/com/sthoray/allright/data/api/RetrofitInstance.kt
+++ b/app/src/main/java/com/sthoray/allright/data/api/RetrofitInstance.kt
@@ -1,6 +1,6 @@
 package com.sthoray.allright.data.api
 
-import com.sthoray.allright.utils.Constants.Companion.BASE_API_URL
+import com.sthoray.allright.util.Constants.Companion.BASE_API_URL
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit

--- a/app/src/main/java/com/sthoray/allright/data/model/search/SearchRequest.kt
+++ b/app/src/main/java/com/sthoray/allright/data/model/search/SearchRequest.kt
@@ -2,7 +2,7 @@ package com.sthoray.allright.data.model.search
 
 import androidx.room.Entity
 import com.google.gson.annotations.SerializedName
-import com.sthoray.allright.utils.SortOrder
+import com.sthoray.allright.util.SortOrder
 
 /**
  * Model for search requests.

--- a/app/src/main/java/com/sthoray/allright/ui/listing/view/ListingActivity.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/listing/view/ListingActivity.kt
@@ -18,8 +18,8 @@ import com.sthoray.allright.ui.base.ViewModelProviderFactory
 import com.sthoray.allright.ui.listing.adapter.ViewPagerAdapter
 import com.sthoray.allright.ui.listing.viewmodel.ListingViewModel
 import com.sthoray.allright.ui.search.view.SearchActivity.Companion.LISTING_ID_KEY
-import com.sthoray.allright.utils.Constants.Companion.BASE_PRODUCT_URL
-import com.sthoray.allright.utils.Resource
+import com.sthoray.allright.util.Constants.Companion.BASE_PRODUCT_URL
+import com.sthoray.allright.util.Resource
 import kotlinx.android.synthetic.main.activity_listing.*
 
 /** The listing activity to display information about a listing. */

--- a/app/src/main/java/com/sthoray/allright/ui/listing/viewmodel/ListingViewModel.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/listing/viewmodel/ListingViewModel.kt
@@ -6,8 +6,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.sthoray.allright.data.model.listing.Listing
 import com.sthoray.allright.data.repository.AppRepository
-import com.sthoray.allright.utils.Internet
-import com.sthoray.allright.utils.Resource
+import com.sthoray.allright.util.Internet
+import com.sthoray.allright.util.Resource
 import kotlinx.coroutines.launch
 import retrofit2.Response
 import java.io.IOException

--- a/app/src/main/java/com/sthoray/allright/ui/main/adapter/BrowseAdapter.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/main/adapter/BrowseAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.sthoray.allright.R
 import com.sthoray.allright.data.model.listing.Category
-import com.sthoray.allright.utils.AppIcon
+import com.sthoray.allright.util.AppIcon
 import kotlinx.android.synthetic.main.item_layout_second_tier_category.view.*
 
 /** Adapter for adapting top level categories into a RecyclerView. */

--- a/app/src/main/java/com/sthoray/allright/ui/main/adapter/HomeAdapter.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/main/adapter/HomeAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.api.load
 import com.sthoray.allright.R
 import com.sthoray.allright.data.model.listing.Category
-import com.sthoray.allright.utils.Constants.Companion.BASE_URL
+import com.sthoray.allright.util.Constants.Companion.BASE_URL
 import kotlinx.android.synthetic.main.item_layout_featured_category.view.*
 
 /**

--- a/app/src/main/java/com/sthoray/allright/ui/main/view/BrowseFragment.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/main/view/BrowseFragment.kt
@@ -13,7 +13,7 @@ import com.sthoray.allright.ui.main.adapter.BrowseAdapter
 import com.sthoray.allright.ui.main.view.MainActivity.Companion.CATEGORY_ID_KEY
 import com.sthoray.allright.ui.main.viewmodel.MainViewModel
 import com.sthoray.allright.ui.search.view.SearchActivity
-import com.sthoray.allright.utils.Resource
+import com.sthoray.allright.util.Resource
 import kotlinx.android.synthetic.main.fragment_browse.*
 
 /**

--- a/app/src/main/java/com/sthoray/allright/ui/main/view/HomeFragment.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/main/view/HomeFragment.kt
@@ -13,7 +13,7 @@ import com.sthoray.allright.ui.main.adapter.HomeAdapter
 import com.sthoray.allright.ui.main.view.MainActivity.Companion.CATEGORY_ID_KEY
 import com.sthoray.allright.ui.main.viewmodel.MainViewModel
 import com.sthoray.allright.ui.search.view.SearchActivity
-import com.sthoray.allright.utils.Resource
+import com.sthoray.allright.util.Resource
 import kotlinx.android.synthetic.main.fragment_home.*
 
 /**

--- a/app/src/main/java/com/sthoray/allright/ui/main/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/main/viewmodel/MainViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.sthoray.allright.data.model.listing.Category
 import com.sthoray.allright.data.model.main.FeatureCategoriesResponse
 import com.sthoray.allright.data.repository.AppRepository
-import com.sthoray.allright.utils.Internet
-import com.sthoray.allright.utils.Resource
+import com.sthoray.allright.util.Internet
+import com.sthoray.allright.util.Resource
 import kotlinx.coroutines.launch
 import retrofit2.Response
 import java.io.IOException

--- a/app/src/main/java/com/sthoray/allright/ui/search/view/ResultsFragment.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/search/view/ResultsFragment.kt
@@ -16,7 +16,7 @@ import com.sthoray.allright.ui.listing.view.ListingActivity
 import com.sthoray.allright.ui.search.adapter.ResultsAdapter
 import com.sthoray.allright.ui.search.view.SearchActivity.Companion.LISTING_ID_KEY
 import com.sthoray.allright.ui.search.viewmodel.SearchViewModel
-import com.sthoray.allright.utils.Resource
+import com.sthoray.allright.util.Resource
 import kotlinx.android.synthetic.main.fragment_results.*
 
 /** Fragment to display search results in a recycler view. */

--- a/app/src/main/java/com/sthoray/allright/ui/search/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/search/viewmodel/SearchViewModel.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.viewModelScope
 import com.sthoray.allright.data.model.search.SearchRequest
 import com.sthoray.allright.data.model.search.SearchResponse
 import com.sthoray.allright.data.repository.AppRepository
-import com.sthoray.allright.utils.Internet
-import com.sthoray.allright.utils.Resource
-import com.sthoray.allright.utils.SortOrder
+import com.sthoray.allright.util.Internet
+import com.sthoray.allright.util.Resource
+import com.sthoray.allright.util.SortOrder
 import kotlinx.coroutines.launch
 import retrofit2.Response
 import java.io.IOException

--- a/app/src/main/java/com/sthoray/allright/util/AppIcon.kt
+++ b/app/src/main/java/com/sthoray/allright/util/AppIcon.kt
@@ -1,4 +1,4 @@
-package com.sthoray.allright.utils
+package com.sthoray.allright.util
 
 import com.sthoray.allright.R
 

--- a/app/src/main/java/com/sthoray/allright/util/Constants.kt
+++ b/app/src/main/java/com/sthoray/allright/util/Constants.kt
@@ -1,4 +1,4 @@
-package com.sthoray.allright.utils
+package com.sthoray.allright.util
 
 /**
  * Constants used in this project.

--- a/app/src/main/java/com/sthoray/allright/util/Internet.kt
+++ b/app/src/main/java/com/sthoray/allright/util/Internet.kt
@@ -1,4 +1,4 @@
-package com.sthoray.allright.utils
+package com.sthoray.allright.util
 
 import android.app.Application
 import android.content.Context

--- a/app/src/main/java/com/sthoray/allright/util/Resource.kt
+++ b/app/src/main/java/com/sthoray/allright/util/Resource.kt
@@ -1,4 +1,4 @@
-package com.sthoray.allright.utils
+package com.sthoray.allright.util
 
 /**
  * Generic resource to wrap around network responses.

--- a/app/src/main/java/com/sthoray/allright/util/SortOrder.kt
+++ b/app/src/main/java/com/sthoray/allright/util/SortOrder.kt
@@ -1,4 +1,4 @@
-package com.sthoray.allright.utils
+package com.sthoray.allright.util
 
 import com.sthoray.allright.R
 

--- a/app/src/sharedTest/java/com/sthoray/allright/util/InternetTest.kt
+++ b/app/src/sharedTest/java/com/sthoray/allright/util/InternetTest.kt
@@ -1,4 +1,4 @@
-package com.sthoray.allright.utils
+package com.sthoray.allright.util
 
 import android.app.Application
 import android.net.ConnectivityManager
@@ -56,7 +56,8 @@ class InternetTest {
         every { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) } returns true
         every { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) } returns true
 
-        val hasConnection = Internet.hasConnection(app)
+        val hasConnection =
+            Internet.hasConnection(app)
 
         verify {
             capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
@@ -82,7 +83,8 @@ class InternetTest {
         every { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) } returns false
         every { capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) } returns false
 
-        val hasConnection = Internet.hasConnection(app)
+        val hasConnection =
+            Internet.hasConnection(app)
 
         verifySequence {
             capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
@@ -103,7 +105,8 @@ class InternetTest {
         every { connectivityManager.activeNetwork } returns null
         every { connectivityManager.getNetworkCapabilities(activeNetwork) } returns capabilities
 
-        val hasConnection = Internet.hasConnection(app)
+        val hasConnection =
+            Internet.hasConnection(app)
         verify(exactly = 0) {
             connectivityManager.getNetworkCapabilities(activeNetwork)
             capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
@@ -122,7 +125,8 @@ class InternetTest {
         every { app.getSystemService(CONNECTIVITY_SERVICE) } returns connectivityManager
         every { connectivityManager.activeNetwork } returns activeNetwork
         every { connectivityManager.getNetworkCapabilities(activeNetwork) } returns null
-        val hasConnection = Internet.hasConnection(app)
+        val hasConnection =
+            Internet.hasConnection(app)
         verify(exactly = 0) {
             capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
             capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
@@ -142,7 +146,8 @@ class InternetTest {
         every {
             connectivityManager.activeNetworkInfo?.type
         } answers { NetworkCapabilities.TRANSPORT_WIFI }
-        val hasConnection = Internet.hasConnection(app)
+        val hasConnection =
+            Internet.hasConnection(app)
 
         verify {
             connectivityManager.activeNetworkInfo
@@ -162,7 +167,8 @@ class InternetTest {
         every {
             connectivityManager.activeNetworkInfo?.type
         } answers { ConnectivityManager.TYPE_DUMMY }
-        val hasConnection = Internet.hasConnection(app)
+        val hasConnection =
+            Internet.hasConnection(app)
 
         verify {
             connectivityManager.activeNetworkInfo
@@ -180,7 +186,8 @@ class InternetTest {
     fun getInternet_API_less_than_M_failure_because_active_network_info_is_null_returns_false() {
         every { app.getSystemService(CONNECTIVITY_SERVICE) } returns connectivityManager
         every { connectivityManager.activeNetworkInfo } returns null
-        val hasConnection = Internet.hasConnection(app)
+        val hasConnection =
+            Internet.hasConnection(app)
 
         verify {
             connectivityManager.activeNetworkInfo

--- a/app/src/sharedTest/java/com/sthoray/allright/util/TestCoroutineRule.kt
+++ b/app/src/sharedTest/java/com/sthoray/allright/util/TestCoroutineRule.kt
@@ -1,4 +1,4 @@
-package com.sthoray.allright.utils
+package com.sthoray.allright.util
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/test/java/com/sthoray/allright/ui/listing/viewmodel/ListingViewModelTest.kt
+++ b/app/src/test/java/com/sthoray/allright/ui/listing/viewmodel/ListingViewModelTest.kt
@@ -6,9 +6,9 @@ import com.google.common.truth.Truth.assertThat
 import com.google.gson.JsonSyntaxException
 import com.sthoray.allright.data.model.listing.Listing
 import com.sthoray.allright.data.repository.AppRepository
-import com.sthoray.allright.utils.Internet
-import com.sthoray.allright.utils.Resource
-import com.sthoray.allright.utils.TestCoroutineRule
+import com.sthoray.allright.util.Internet
+import com.sthoray.allright.util.Resource
+import com.sthoray.allright.util.TestCoroutineRule
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK

--- a/app/src/test/java/com/sthoray/allright/ui/main/viewmodel/MainViewModelTest.kt
+++ b/app/src/test/java/com/sthoray/allright/ui/main/viewmodel/MainViewModelTest.kt
@@ -7,9 +7,9 @@ import com.google.gson.JsonSyntaxException
 import com.sthoray.allright.data.model.listing.Category
 import com.sthoray.allright.data.model.main.FeatureCategoriesResponse
 import com.sthoray.allright.data.repository.AppRepository
-import com.sthoray.allright.utils.Internet
-import com.sthoray.allright.utils.Resource
-import com.sthoray.allright.utils.TestCoroutineRule
+import com.sthoray.allright.util.Internet
+import com.sthoray.allright.util.Resource
+import com.sthoray.allright.util.TestCoroutineRule
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK

--- a/app/src/test/java/com/sthoray/allright/ui/search/viewmodel/SearchViewModelTest.kt
+++ b/app/src/test/java/com/sthoray/allright/ui/search/viewmodel/SearchViewModelTest.kt
@@ -9,9 +9,9 @@ import com.sthoray.allright.data.model.search.SearchRequest
 import com.sthoray.allright.data.model.search.SearchResponse
 import com.sthoray.allright.data.model.search.SearchResponseMetadata
 import com.sthoray.allright.data.repository.AppRepository
-import com.sthoray.allright.utils.Internet
-import com.sthoray.allright.utils.Resource
-import com.sthoray.allright.utils.TestCoroutineRule
+import com.sthoray.allright.util.Internet
+import com.sthoray.allright.util.Resource
+import com.sthoray.allright.util.TestCoroutineRule
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi


### PR DESCRIPTION
There were two different "utilities" test packages: named util and utils  
This commit moves the tests from the "utils" test package to "util"  and refactors the production "utils" package to "util" 