### PR TITLE
Switch to FragmentContainerView in Activities

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0-alpha02'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.preference:preference:1.1.1'

--- a/app/src/main/java/com/sthoray/allright/ui/main/view/MainActivity.kt
+++ b/app/src/main/java/com/sthoray/allright/ui/main/view/MainActivity.kt
@@ -3,6 +3,7 @@ package com.sthoray.allright.ui.main.view
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import com.sthoray.allright.R
@@ -55,8 +56,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setupBottomNav() {
-        bottomNavigationView.setupWithNavController(
-            navigationHostFragment.findNavController()
-        )
+        val navHostFragment = supportFragmentManager
+            .findFragmentById(R.id.navigationHostFragment) as NavHostFragment
+        bottomNavigationView.setupWithNavController(navHostFragment.findNavController())
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".ui.main.view.MainActivity">
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/navigationHostFragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".ui.search.view.SearchActivity">
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/searchHostFragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="primary_orange">#fb8a00</color>
-    <color name="primary_orange_light">#ffa525</color>
+    <!-- <color name="primary_orange_light">#ffa525</color> -->
     <color name="primary_orange_dark">#ef6a01</color>
     <color name="primary_orange_text">#ffffff</color>
 </resources>


### PR DESCRIPTION
fixes "fragment" warning in Android Studio by changing the fragment tag to a fragment container view.
I am not sure what the difference is.